### PR TITLE
Update lisp/muse-texinfo.el

### DIFF
--- a/lisp/muse-texinfo.el
+++ b/lisp/muse-texinfo.el
@@ -67,7 +67,7 @@
 @setfilename <lisp>(concat (muse-page-name) \".info\")</lisp>
 @settitle <lisp>(muse-publishing-directive \"title\")</lisp>
 
-@documentencoding iso-8859-1
+@documentencoding ISO-8859-1
 
 @iftex
 @finalout


### PR DESCRIPTION
Texinfo does not understand document encoding iso-8859-1: corrected to ISO-8859-1
