### PR TITLE
Fix comment regexp

### DIFF
--- a/lisp/muse-publish.el
+++ b/lisp/muse-publish.el
@@ -108,7 +108,7 @@ If non-nil, publish comments using the markup of the current style."
     (1200 "\\`#\\([a-zA-Z-]+\\)\\s-+\\(.+\\)\n+" 0 directive)
 
     ;; commented lines
-    (1250 ,(concat "^;\\(?:[" muse-regexp-blank "]+\\(.+\\)\\|$\\|'\\)")
+    (1250 ,(concat "^;\\(?:[" muse-regexp-blank "]+\\(.+\\)\\|$\\|\\'\\)")
           0 comment)
 
     ;; markup tags


### PR DESCRIPTION
' was not escaped properly so it matched literal "'" instead of buffer end.

As a result, comment like
;'foobar
resulted in publishing "foobar" as if it was not commented.