### PR TITLE
convert a muse-init.el example to UTF-8

### DIFF
--- a/examples/johnw/muse-init.el
+++ b/examples/johnw/muse-init.el
@@ -412,11 +412,11 @@
 
 ;;(setq
 ;; muse-cite-titles
-;; '(("Bah·'u'll·h"
-;;    ("Kit·b-i-Õq·n"
+;; '(("Bah√°'u'll√°h"
+;;    ("Kit√°b-i-√çq√°n"
 ;;     "http://bahai-library.com/?file=bahaullah_kitab_iqan.html"
 ;;     "http://bahai-library.com/?file=bahaullah_kitab_iqan.html#%d"))
-;;   ("`Abdu'l-Bah·"
+;;   ("`Abdu'l-Bah√°"
 ;;    ("Promulgation of Universal Peace"
 ;;     "http://bahai-library.com/?file=abdulbaha_promulgation_universal_peace.html"
 ;;     "http://www.bahai-library.com/writings/abdulbaha/pup/pup.html#%d"))))


### PR DESCRIPTION
* Original patch from Nicholas D. Steeves: https://salsa.debian.org/emacsen-team/muse-el/-/blob/master/debian/patches/0005-convert-a-muse-init.el-example-to-UTF-8.patch
* This is to be conformant with Debian's UTF-8 release goals: https://wiki.debian.org/ReleaseGoals/utf-8